### PR TITLE
Storage limits node-based disk limit update

### DIFF
--- a/reference-limits-aws.adoc
+++ b/reference-limits-aws.adoc
@@ -32,7 +32,7 @@ For some configurations, disk limits prevent you from reaching the capacity limi
 | PAYGO Explore	| 2 TiB (data tiering is not supported with Explore)
 | PAYGO Standard | 10 TiB
 | PAYGO Premium | 368 TiB
-| Node-based license | 368 TiB per license
+| Node-based license | 2 PiB (requires multiple licenses)
 | Capacity-based license | 2 PiB
 
 |===
@@ -53,7 +53,8 @@ Note the following:
 
 * The disk limits below are specific to disks that contain user data. The limits do not include the boot disk and root disk.
 
-* You can now purchase multiple node-based licenses for a Cloud Volumes ONTAP BYOL system to allocate more than 368 TiB of capacity. The number of licenses that you can purchase for a single node system or HA pair is unlimited. Be aware that disk limits can prevent you from reaching the capacity limit by using disks alone. You can go beyond the disk limit by https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/concept-data-tiering.html[tiering inactive data to object storage^]. https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-manage-node-licenses.html[Learn how to add additional system licenses to Cloud Volumes ONTAP^].
+* You can purchase multiple node-based licenses for a Cloud Volumes ONTAP BYOL single node or HA pair system to allocate more than 368 TiB of capacity, up to the maximum tested and supported system capacity limit of 2 PiB. Be aware that disk limits can prevent you from reaching the capacity limit by using disks alone. You can go beyond the disk limit by https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/concept-data-tiering.html[tiering inactive data to object storage^]. https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-manage-node-licenses.html[Learn how to add additional system licenses to Cloud Volumes ONTAP^]. Though Cloud Volumes ONTAP supports up to the maximum tested and supported system capacity of 2 PiB, crossing the 2 PiB limit results in an unsupported system configuration. 
+** AWS Secret Cloud and Top Secret Cloud regions support purchases of multiple node-based licenses starting with Cloud Volumes ONTAP 9.12.1. 
 
 === Single node with a Premium license
 
@@ -79,7 +80,7 @@ Note the following:
 2+| Max system capacity with multiple licenses
 
 2+| | *Disks alone* | *Disks + data tiering* | *Disks alone* | *Disks + data tiering*
-| c5, m5, and r5 instances | 21 ^1^ | 336 TiB | 368 TiB | 336 TiB | 368 TiB x each license
+| c5, m5, and r5 instances | 21 ^1^ | 336 TiB | 368 TiB | 336 TiB | 2 PiB
 |===
 
 . 21 data disks is the limit for _new_ deployments of Cloud Volumes ONTAP. If you upgrade a system that was created with version 9.7 or earlier, then the system continues to support 22 disks. One less data disk is supported on new systems that use these instance types because of the addition of a core disk starting with the 9.8 release.
@@ -121,7 +122,7 @@ Note the following:
 
 2+| | *Disks alone* | *Disks + data tiering* | *Disks alone* | *Disks + data tiering*
 
-| c5, m5, and r5 instances | 18 ^1^ | 288 TiB | 368 TiB | 288 TiB | 368 TiB x each license
+| c5, m5, and r5 instances | 18 ^1^ | 288 TiB | 368 TiB | 288 TiB | 2 PiB 
 |===
 
 . 18 data disks is the limit for _new_ deployments of Cloud Volumes ONTAP. If you upgrade a system that was created with version 9.7 or earlier, then the system continues to support 19 disks. One less data disk is supported on new systems that use these instance types because of the addition of a core disk starting with the 9.8 release.

--- a/reference-limits-azure.adoc
+++ b/reference-limits-azure.adoc
@@ -30,7 +30,7 @@ NetApp doesn't support exceeding the system capacity limit. If you reach the lic
 | PAYGO Explore	| 2 TiB (data tiering is not supported with Explore)
 | PAYGO Standard | 10 TiB
 | PAYGO Premium | 368 TiB
-| Node-based license | 368 TiB per license
+| Node-based license | 2 PiB (requires multiple licenses)
 | Capacity-based license | 2 PiB
 
 |===
@@ -49,7 +49,7 @@ The tables below show the maximum system capacity by VM size with disks alone, a
 
 * HA systems use Premium page blobs as disks, with up to 8 TiB per page blob. The number of supported disks varies by VM size.
 
-NOTE: You can purchase multiple node-based licenses for a Cloud Volumes ONTAP BYOL system to allocate more than 368 TiB of capacity. The number of licenses that you can purchase for a single node system or HA pair is unlimited. Be aware that disk limits can prevent you from reaching the capacity limit by using disks alone. You can go beyond the disk limit by https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/concept-data-tiering.html[tiering inactive data to object storage^]. https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-manage-node-licenses.html[Learn how to add additional system licenses to Cloud Volumes ONTAP^].
+NOTE: You can purchase multiple node-based licenses for a Cloud Volumes ONTAP BYOL single node or HA pair system to allocate more than 368 TiB of capacity, up to the maximum tested and supported system capacity limit of 2 PiB. Be aware that disk limits can prevent you from reaching the capacity limit by using disks alone. You can go beyond the disk limit by https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/concept-data-tiering.html[tiering inactive data to object storage^]. https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-manage-node-licenses.html[Learn how to add additional system licenses to Cloud Volumes ONTAP^]. Though Cloud Volumes ONTAP supports up to the maximum tested and supported system capacity of 2 PiB, crossing the 2 PiB limit results in an unsupported system configuration.
 
 === Single node with a Premium license
 
@@ -80,19 +80,19 @@ NOTE: You can purchase multiple node-based licenses for a Cloud Volumes ONTAP BY
 
 2+| | *Disks alone* | *Disks + data tiering* | *Disks alone* | *Disks + data tiering*
 
-| DS3_v2 | 13 | 368 TiB | 368 TiB | 416 TiB | 368 TiB x each license
-| DS4_v2 | 29 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
-| DS5_v2 | 61 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
-| DS13_v2 | 29 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
-| DS14_v2 | 61 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
-| DS15_v2 | 61 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
-| E4s_v3 | 5 | 160 TiB | 368 TiB | 160 TiB | 368 TiB x each license
-| E8s_v3 | 13 | 368 TiB | 368 TiB | 416 TiB | 368 TiB x each license
-| E32s_v3 | 29 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
-| E48s_v3 | 29 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
-| E64is_v3 | 29 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
-| L8s_v2 | 13 | 368 TiB | 368 TiB | 416 TiB | 368 TiB x each license
-| E80ids_v4 | 61 | 368 TiB | 368 TiB | 896 TiB | 368 TiB x each license
+| DS3_v2 | 13 | 368 TiB | 368 TiB | 416 TiB | 2 PiB
+| DS4_v2 | 29 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
+| DS5_v2 | 61 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
+| DS13_v2 | 29 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
+| DS14_v2 | 61 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
+| DS15_v2 | 61 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
+| E4s_v3 | 5 | 160 TiB | 368 TiB | 160 TiB | 2 PiB
+| E8s_v3 | 13 | 368 TiB | 368 TiB | 416 TiB | 2 PiB
+| E32s_v3 | 29 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
+| E48s_v3 | 29 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
+| E64is_v3 | 29 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
+| L8s_v2 | 13 | 368 TiB | 368 TiB | 416 TiB | 2 PiB
+| E80ids_v4 | 61 | 368 TiB | 368 TiB | 896 TiB | 2 PiB
 |===
 
 === Single node with capacity-based licensing
@@ -147,14 +147,14 @@ NOTE: You can purchase multiple node-based licenses for a Cloud Volumes ONTAP BY
 
 2+| | *Disks alone* | *Disks + data tiering* | *Disks alone* | *Disks + data tiering*
 
-| DS4_v2 | 29 | 232 TiB | 368 TiB | 232 TiB | 368 TiB x each license
-| DS5_v2 | 61 | 368 TiB | 368 TiB | 488 TiB | 368 TiB x each license
-| DS13_v2 | 29 | 232 TiB | 368 TiB | 232 TiB | 368 TiB x each license
-| DS14_v2 | 61 | 368 TiB | 368 TiB | 488 TiB | 368 TiB x each license
-| DS15_v2 | 61 | 368 TiB | 368 TiB | 488 TiB | 368 TiB x each license
-| E8s_v3 | 13 | 104 TiB | 368 TiB | 104 TiB | 368 TiB x each license
-| E48s_v3 | 29 | 232 TiB | 368 TiB | 232 TiB | 368 TiB x each license
-| E80ids_v4 | 61 | 368 TiB | 368 TiB | 488 TiB | 368 TiB x each license
+| DS4_v2 | 29 | 232 TiB | 368 TiB | 232 TiB | 2 PiB
+| DS5_v2 | 61 | 368 TiB | 368 TiB | 488 TiB | 2 PiB
+| DS13_v2 | 29 | 232 TiB | 368 TiB | 232 TiB | 2 PiB
+| DS14_v2 | 61 | 368 TiB | 368 TiB | 488 TiB | 2 PiB
+| DS15_v2 | 61 | 368 TiB | 368 TiB | 488 TiB | 2 PiB
+| E8s_v3 | 13 | 104 TiB | 368 TiB | 104 TiB | 2 PiB
+| E48s_v3 | 29 | 232 TiB | 368 TiB | 232 TiB | 2 PiB
+| E80ids_v4 | 61 | 368 TiB | 368 TiB | 488 TiB | 2 PiB
 |===
 
 === HA pairs with capacity-based licensing

--- a/reference-limits-gcp.adoc
+++ b/reference-limits-gcp.adoc
@@ -32,7 +32,7 @@ For some configurations, disk limits prevent you from reaching the capacity limi
 | PAYGO Explore	| 2 TB (data tiering is not supported with Explore)
 | PAYGO Standard | 10 TB
 | PAYGO Premium | 368 TB
-| Node-based license | 368 TB per license
+| Node-based license | 2 PiB (requires multiple licenses)
 | Capacity-based license | 2 PiB
 
 |===
@@ -67,7 +67,7 @@ The table below shows the maximum system capacity with disks alone, and with dis
 
 == Aggregate limits
 
-Cloud Volumes ONTAP groups Google Cloud Platform disks into _aggregates_. Aggregates provide storage to volumes.
+Cloud Volumes ONTAP groups Google Cloud disks into _aggregates_. Aggregates provide storage to volumes.
 
 [cols=2*,width=55%,options="header,autowidth"]
 |===
@@ -99,7 +99,7 @@ Notes:
 | Limit
 
 | *Storage virtual machines (SVMs)*	| Maximum number for Cloud Volumes ONTAP
-(HA pair or single node) | One data-serving SVM and one destination SVM used for disaster recovery. You can activate the destination SVM for data access if there’s an outage on the source SVM. ^1^
+(HA pair or single node) | One data-serving SVM and one destination SVM used for disaster recovery. You can activate the destination SVM for data access if there's an outage on the source SVM. ^1^
 
 The one data-serving SVM spans the entire Cloud Volumes ONTAP system (HA pair or single node).
 .2+| *Files*	| Maximum size | 16 TB


### PR DESCRIPTION
The hotfix includes the following for node-based licenses disk limits:

- disk limit updates in AWS, Azure, and Google Cloud
- update note on license stacking